### PR TITLE
Avoid buffer reassignment error in Chrome

### DIFF
--- a/public/web-audio-api/audioparam/index.coffee
+++ b/public/web-audio-api/audioparam/index.coffee
@@ -100,7 +100,9 @@ $ ->
     bufSrc.buffer.getChannelData(0).set [ 1, 1 ]
 
     # fix for Firefox
-    bufSrc.buffer = bufSrc.buffer
+    try
+      bufSrc.buffer = bufSrc.buffer
+    catch e
 
     bufSrc.loop = true
     bufSrc.start 0

--- a/public/web-audio-api/audioparam/index.js
+++ b/public/web-audio-api/audioparam/index.js
@@ -92,7 +92,11 @@
       bufSrc = audioContext.createBufferSource();
       bufSrc.buffer = audioContext.createBuffer(1, 2, 44100);
       bufSrc.buffer.getChannelData(0).set([1, 1]);
-      bufSrc.buffer = bufSrc.buffer;
+      try {
+        bufSrc.buffer = bufSrc.buffer;
+      } catch (e) {
+        
+      }
       bufSrc.loop = true;
       bufSrc.start(0);
       bufSrc.connect(gain);


### PR DESCRIPTION
This firefox workaround was throwing an error for chrome, so I wrapped it in a try/catch. Awesome tool!
